### PR TITLE
fix: bad constructor type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,7 +36,7 @@ export interface BACKGROUND_TYPESI {
 export declare class TNSFancyAlertButton {
   label: string;
   action: (arg?: any) => void;
-  constructor(model?: any) {}
+  constructor(model?: any);
 }
 export declare class TNSFancyAlert {
   static SUPPORTED_TYPES: SUPPORTED_TYPESI;


### PR DESCRIPTION
Fixes compile error: `ERROR in node_modules/nativescript-fancyalert/index.d.ts(49,28): error TS1183: An implementation cannot be declared in ambient contexts`